### PR TITLE
Make the script POSIX compatible (at least I hope so)

### DIFF
--- a/menusearx
+++ b/menusearx
@@ -1,75 +1,74 @@
 #!/bin/sh
 
 # check if necessary programs are installed
-[ ! "$(which jq)" ] && echo "Please install jq!" && exit 1
+command -v jq >/dev/null || { echo 'Please install jq!'; exit 1; }
 
 # assign menu prorgram
-menu="dmenu -i -l 15" # uncomment line to use dmenu
-#menu="rofi -dmenu -i" # uncomment line to use rofi
+menu='dmenu -i -l 15'
+#menu='rofi -dmenu -i'
 
 # if notify-send is not installed, use echo as notifier for errors
-notifier="notify-send"
+notifier='notify-send'
 
 # searx instance you will be getting the results from
-instance=""
+instance=
+#:r !grep '\* https://' README.md | sed 's/^\s*\*\s*/\#instance=/'
+#:<grep '\* https://' README.md | sed 's/^\s*\*\s*/\#instance=/'
 
 # checks if instance is empty
-if [ -z $instance ]; then
-	$notifier "Empty instance"
+if [ -z "$instance" ]; then
+	$notifier 'Empty instance'
 	exit 1
 fi
 
 # browser
-browser=surf
+browser=${BROWSER:-surf}
 
-# search term
-query="$(echo | $menu -p  "Search")"
-
-# check if query is empty
-if [ -z $query ]; then
-        $notifier "Empty query"
+# search term, exit with error if query is empty
+query=$($menu -p 'Search' <&-) || {
+	$notifier 'Empty query'
 	exit 1
-fi
+}
 
-# sanatise query
-query=$(sed \
+# sanitise query
+query=$(printf "$query" | \
+	sed \
 	-e 's|+|%2B|g'\
 	-e 's|#|%23|g'\
 	-e 's|&|%26|g'\
 	-e 's| |+|g'\
-	<<< "$query")
+	)
 
 # where any temporary files will be stored
-cachedir="/tmp/menusearx"
+cachedir=${XDG_CACHE_HOME:-/tmp/menusearx}
 
 # if cachedir does not exist, create it
-if [ ! -d "$cachedir" ]; then
+[ -d "$cachedir" ] || {
 	echo "$cachedir does not exist, creating..."
 	mkdir -p "$cachedir"
-fi
+}
 
 # gets results json
-curl -o $cachedir"results.json" -s $instance"/search?q="$query"&format=json"
+curl -o "$cachedir/results.json" -s "$instance/search?q=$query&format=json"
 
-if grep -q "Rate limit exceeded" $cachedir"results.json"; then
-	$notifier "Instance rate limit exceeded"
+if grep -qF 'Rate limit exceeded' "$cachedir/results.json"; then
+	$notifier 'Instance rate limit exceeded'
 	exit 1
-elif grep -q "Blocked" $cachedir"results.json"; then
-        $notifier "Instance blocked program"
+elif grep -qF 'Blocked' "$cachedir/results.json"; then
+        $notifier 'Instance blocked program'
 	exit 1
 fi
 
-# gets individual urls
-jq '.' < $cachedir"results.json" | grep '"url":' | grep -Eo "http(s|)://.*" | sed -e 's|[",]||g' > $cachedir"links.txt"
+# gets individual titles and urls
+jq -r '.results[] | [.title, .url] | join("@")' "$cachedir/results.json" |
+column -t -s '@' >"$cachedir/links.txt"
 
-# prompts user to select link
-url="$($menu -p "Select" < $cachedir"links.txt")"
-
-# check if the url is invalid, and if not,  opens link in browser
-if [ -z $url ]; then
-	$notifier "Invalid URL"
+# prompts user to select result, open in browser if non-empty
+if url=$($menu -p 'Select' <"$cachedir/links.txt" | grep -o 'https://.*'); then
+	$browser "$url"
 else
-	$browser $url
+	$notifier 'Invalid URL'
 fi
 
 rm "${cachedir:?}"/*
+


### PR DESCRIPTION
change unnecessary double quotes to single quotes
remove bashisms
default browser is the global var BROWSER or surf if BROWSER is not set
default cache dir is XDG_CACHE_HOME or /tmp/menusearx if XDG_CACHE_HOME is not set
the content of results is now parsed by jq only
links now contains url and titles